### PR TITLE
Add function comment and break out comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,24 @@ Projektet använder MySQL 8.0+ med raw SQL queries.
 - Development: `.env` (lokal MySQL)
 - Production: `.env.production` (managed database)
 
-**Schema:** 16 tabeller definierade i `schema.sql`
+**Schema:** tabeller definierade i `schema.sql`
+
+## 🧵 Trådar och kommentarer
+
+Nya funktioner i feeden:
+- Kommentera inlägg.
+- Stäng/öppna svarstråd (inläggsägare).
+- Bryt ut diskussion till privat tråd med valda deltagare.
+
+Regler vid utbrytning:
+- Inlägg/svar före utbrytning förblir synliga för alla.
+- Nya svar efter utbrytning syns endast för inläggsägare + valda deltagare.
+- Inläggsägaren läggs till automatiskt i utbruten tråd.
+
+Relevanta API-endpoints:
+- `POST /api/posts/<post_id>/comments`
+- `POST /api/posts/<post_id>/reply-lock`
+- `POST /api/posts/<post_id>/discussion-groups`
 
 ## 🔎 Kodkvalitet (Lint)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,13 @@ from dotenv import load_dotenv
 from flask import Flask, render_template, redirect, url_for, request, flash, jsonify
 from flask_login import LoginManager, current_user, login_required
 from pymysql import cursors
-from .db import get_db, init_connection_pool, ensure_default_user, ensure_default_admin
+from .db import (
+    get_db,
+    init_connection_pool,
+    ensure_default_user,
+    ensure_default_admin,
+    ensure_post_thread_controls_schema,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +53,7 @@ def create_app(test_config: dict | None = None) -> Flask:
         ensure_default_user(app)
         if env == "development":
             ensure_default_admin(app)
+        ensure_post_thread_controls_schema(app)
     except Exception as e:
         logger.error(f"Failed to initialize database connection: {e}")
         if app.config.get("ENV") == "production":
@@ -100,6 +107,7 @@ def create_app(test_config: dict | None = None) -> Flask:
     def index():
         try:
             default_avatar_url = "https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=100&h=100&fit=crop"
+            viewer_id = current_user.get_id() if current_user.is_authenticated else None
 
             with get_db(app) as conn:
                 cursor = conn.cursor(cursors.DictCursor)
@@ -108,7 +116,38 @@ def create_app(test_config: dict | None = None) -> Flask:
                     SELECT p.post_id, p.content, p.created_at, p.updated_at,
                            u.user_id, u.username, u.display_name,
                            m.url AS profile_image_url,
-                           COALESCE(rc.reply_count, 0) AS reply_count
+                           COALESCE(rc.reply_count, 0) AS reply_count,
+                           COALESCE(p.replies_closed, FALSE) AS replies_closed,
+                           p.replies_closed_at,
+                           p.restricted_group_id,
+                           p.restricted_at,
+                           CASE
+                               WHEN p.restricted_group_id IS NULL THEN TRUE
+                               WHEN %s IS NULL THEN FALSE
+                               WHEN p.user_id = %s THEN TRUE
+                               WHEN EXISTS (
+                                   SELECT 1
+                                   FROM GroupMembers gm
+                                   WHERE gm.group_id = p.restricted_group_id
+                                     AND gm.user_id = %s
+                               ) THEN TRUE
+                               ELSE FALSE
+                           END AS can_view_replies,
+                           CASE
+                               WHEN p.restricted_group_id IS NOT NULL AND %s IS NOT NULL THEN
+                                   CASE
+                                       WHEN p.user_id = %s THEN TRUE
+                                       WHEN EXISTS (
+                                           SELECT 1
+                                           FROM GroupMembers gm2
+                                           WHERE gm2.group_id = p.restricted_group_id
+                                             AND gm2.user_id = %s
+                                       ) THEN TRUE
+                                       ELSE FALSE
+                                   END
+                               WHEN p.restricted_group_id IS NULL AND COALESCE(p.replies_closed, FALSE) = FALSE THEN TRUE
+                               ELSE FALSE
+                           END AS can_comment_replies
                     FROM Posts p
                     LEFT JOIN Users u ON p.user_id = u.user_id
                     LEFT JOIN Media m ON m.media_id = u.profile_media_id AND m.is_deleted = FALSE
@@ -121,16 +160,23 @@ def create_app(test_config: dict | None = None) -> Flask:
                     WHERE p.is_deleted = FALSE
                     ORDER BY p.created_at DESC
                     LIMIT 50;
-                    """
+                    """,
+                    (viewer_id, viewer_id, viewer_id, viewer_id, viewer_id, viewer_id),
                 )
                 db_posts = cursor.fetchall()
-                post_ids = [row.get("post_id") for row in db_posts if row.get("post_id")]
+                post_ids = [
+                    row.get("post_id")
+                    for row in db_posts
+                    if row.get("post_id")
+                ]
                 replies_by_post = {}
+                participants_by_post = {}
                 if post_ids:
                     placeholders = ", ".join(["%s"] * len(post_ids))
                     cursor.execute(
                         f"""
                         SELECT r.reply_id, r.parent_post_id, r.content, r.created_at,
+                               COALESCE(r.is_private_after_split, FALSE) AS is_private_after_split,
                                u.user_id, u.username, u.display_name,
                                m.url AS profile_image_url
                         FROM Replies r
@@ -146,11 +192,21 @@ def create_app(test_config: dict | None = None) -> Flask:
                         parent_post_id = reply.get("parent_post_id")
                         if not parent_post_id:
                             continue
+                        participant = {
+                            "id": reply.get("user_id"),
+                            "name": reply.get("display_name")
+                            or reply.get("username")
+                            or "Unknown",
+                        }
+                        if participant["id"]:
+                            participants_by_post.setdefault(parent_post_id, {})
+                            participants_by_post[parent_post_id][participant["id"]] = participant
                         replies_by_post.setdefault(parent_post_id, []).append(
                             {
                                 "id": reply.get("reply_id"),
                                 "content": reply.get("content"),
                                 "timestamp": reply.get("created_at"),
+                                "isPrivateAfterSplit": bool(reply.get("is_private_after_split")),
                                 "author": {
                                     "id": reply.get("user_id"),
                                     "name": reply.get("display_name")
@@ -166,9 +222,55 @@ def create_app(test_config: dict | None = None) -> Flask:
             for row in db_posts:
                 display_name = row.get("display_name") or row.get("username") or "Unknown"
                 username = row.get("username") or "unknown"
+                post_id = row.get("post_id")
+                all_replies = replies_by_post.get(post_id, [])
+                can_view_all_replies = bool(row.get("can_view_replies"))
+                restricted_at = row.get("restricted_at")
+                visible_comment_count = 0
+                if can_view_all_replies:
+                    visible_replies = all_replies
+                elif row.get("restricted_group_id"):
+                    visible_replies = [
+                        reply for reply in all_replies if not reply.get("isPrivateAfterSplit")
+                    ]
+                else:
+                    visible_replies = all_replies
+
+                rendered_comments = list(visible_replies)
+                if row.get("restricted_group_id") and restricted_at:
+                    before_split = [reply for reply in all_replies if not reply.get("isPrivateAfterSplit")]
+                    if can_view_all_replies:
+                        after_split = [reply for reply in all_replies if reply.get("isPrivateAfterSplit")]
+                        rendered_comments = before_split + [
+                            {
+                                "isMarker": True,
+                                "label": "Diskussionen bröts ut här",
+                                "timestamp": restricted_at,
+                            }
+                        ] + after_split
+                    else:
+                        rendered_comments = before_split + [
+                            {
+                                "isMarker": True,
+                                "label": "Diskussionen bröts ut här",
+                                "timestamp": restricted_at,
+                            }
+                        ]
+
+                if row.get("replies_closed") and not row.get("restricted_group_id"):
+                    rendered_comments = rendered_comments + [
+                        {
+                            "isMarker": True,
+                            "label": "Svarstråden stängdes här",
+                            "timestamp": row.get("replies_closed_at"),
+                        }
+                    ]
+
+                visible_comment_count = len([reply for reply in rendered_comments if not reply.get("isMarker")])
+
                 posts.append(
                     {
-                        "id": row.get("post_id"),
+                        "id": post_id,
                         "author": {
                             "id": row.get("user_id"),
                             "name": display_name,
@@ -178,8 +280,21 @@ def create_app(test_config: dict | None = None) -> Flask:
                         "content": row.get("content"),
                         "timestamp": row.get("created_at"),
                         "likes": 0,
-                        "comments": int(row.get("reply_count") or 0),
-                        "commentsList": replies_by_post.get(row.get("post_id"), []),
+                        "comments": visible_comment_count,
+                        "commentsList": rendered_comments,
+                        "commentParticipants": (
+                            [
+                                participant
+                                for participant in list(participants_by_post.get(post_id, {}).values())
+                                if participant.get("id") != viewer_id
+                            ]
+                            if can_view_all_replies
+                            else []
+                        ),
+                        "threadClosed": bool(row.get("replies_closed")),
+                        "canViewComments": True,
+                        "canComment": bool(row.get("can_comment_replies")),
+                        "threadRestricted": bool(row.get("restricted_group_id")),
                         "bookmarks": 0,
                         "isLiked": False,
                         "isBookmarked": False,
@@ -380,7 +495,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                 cursor = conn.cursor(cursors.DictCursor)
                 cursor.execute(
                     """
-                    SELECT post_id
+                    SELECT post_id, replies_closed, restricted_group_id, user_id
                     FROM Posts
                     WHERE post_id = %s AND is_deleted = FALSE;
                     """,
@@ -390,15 +505,34 @@ def create_app(test_config: dict | None = None) -> Flask:
                 if not post:
                     cursor.close()
                     return {"error": "Post not found"}, 404
+                is_private_thread = bool(post.get("restricted_group_id"))
+                if is_private_thread:
+                    cursor.execute(
+                        """
+                        SELECT 1
+                        FROM GroupMembers
+                        WHERE group_id = %s AND user_id = %s
+                        LIMIT 1;
+                        """,
+                        (post.get("restricted_group_id"), user_id),
+                    )
+                    is_member = cursor.fetchone() is not None
+                    is_owner = post.get("user_id") == user_id
+                    if not is_member and not is_owner:
+                        cursor.close()
+                        return {"error": "Thread is private after split"}, 403
+                if post.get("replies_closed") and not is_private_thread:
+                    cursor.close()
+                    return {"error": "Thread is closed for replies"}, 403
 
                 cursor.execute(
                     """
                     INSERT INTO Replies (
-                        reply_id, parent_post_id, parent_reply_id, user_id, content, created_at, updated_at
+                        reply_id, parent_post_id, parent_reply_id, user_id, content, is_private_after_split, created_at, updated_at
                     )
-                    VALUES (%s, %s, NULL, %s, %s, %s, %s);
+                    VALUES (%s, %s, NULL, %s, %s, %s, %s, %s);
                     """,
-                    (reply_id, post_id, user_id, content, now, now),
+                    (reply_id, post_id, user_id, content, is_private_thread, now, now),
                 )
 
                 cursor.execute(
@@ -427,5 +561,178 @@ def create_app(test_config: dict | None = None) -> Flask:
         except Exception as e:
             logger.error(f"Error creating comment (api): {e}")
             return {"error": "Failed to create comment"}, 500
+
+    @app.route("/api/posts/<post_id>/reply-lock", methods=["POST"])
+    @login_required
+    def toggle_post_reply_lock(post_id):
+        payload = request.get_json(silent=True) or {}
+        requested_state = payload.get("is_closed")
+        if not isinstance(requested_state, bool):
+            return {"error": "is_closed must be a boolean"}, 400
+
+        user_id = current_user.get_id()
+        now = datetime.now().isoformat(timespec="seconds")
+
+        try:
+            with get_db(app) as conn:
+                cursor = conn.cursor(cursors.DictCursor)
+                cursor.execute(
+                    """
+                    SELECT post_id, user_id, replies_closed, restricted_group_id
+                    FROM Posts
+                    WHERE post_id = %s AND is_deleted = FALSE;
+                    """,
+                    (post_id,),
+                )
+                post = cursor.fetchone()
+                if not post:
+                    cursor.close()
+                    return {"error": "Post not found"}, 404
+                if post.get("user_id") != user_id:
+                    cursor.close()
+                    return {"error": "Only post owner can change thread state"}, 403
+                if post.get("restricted_group_id") and not requested_state:
+                    cursor.close()
+                    return {"error": "Thread is private after split and cannot be reopened"}, 400
+
+                cursor.execute(
+                    """
+                    UPDATE Posts
+                    SET replies_closed = %s,
+                        replies_closed_by = %s,
+                        replies_closed_at = CASE WHEN %s THEN %s ELSE NULL END,
+                        updated_at = %s
+                    WHERE post_id = %s;
+                    """,
+                    (requested_state, user_id, requested_state, now, now, post_id),
+                )
+                cursor.close()
+
+            return {"post_id": post_id, "is_closed": requested_state}, 200
+        except Exception as e:
+            logger.error(f"Error toggling reply lock: {e}")
+            return {"error": "Failed to update thread state"}, 500
+
+    @app.route("/api/posts/<post_id>/discussion-groups", methods=["POST"])
+    @login_required
+    def create_discussion_group(post_id):
+        from uuid import uuid4
+
+        payload = request.get_json(silent=True) or {}
+        selected_user_ids = payload.get("participant_user_ids") or []
+        group_name = (payload.get("name") or "").strip()
+        creator_id = current_user.get_id()
+
+        if not isinstance(selected_user_ids, list):
+            return {"error": "participant_user_ids must be a list"}, 400
+
+        cleaned_selected_ids = [str(uid).strip() for uid in selected_user_ids if str(uid).strip()]
+        cleaned_selected_ids = list(dict.fromkeys(cleaned_selected_ids))
+        cleaned_selected_ids = [uid for uid in cleaned_selected_ids if uid != creator_id]
+
+        if not cleaned_selected_ids:
+            return {"error": "Choose at least one other participant"}, 400
+
+        try:
+            now = datetime.now().isoformat(timespec="seconds")
+            with get_db(app) as conn:
+                cursor = conn.cursor(cursors.DictCursor)
+                cursor.execute(
+                    """
+                    SELECT post_id, user_id, content
+                    FROM Posts
+                    WHERE post_id = %s AND is_deleted = FALSE;
+                    """,
+                    (post_id,),
+                )
+                post = cursor.fetchone()
+                if not post:
+                    cursor.close()
+                    return {"error": "Post not found"}, 404
+                if post.get("user_id") != creator_id:
+                    cursor.close()
+                    return {"error": "Only post owner can split discussion"}, 403
+
+                cursor.execute(
+                    """
+                    SELECT DISTINCT r.user_id, COALESCE(u.display_name, u.username, 'Unknown') AS name
+                    FROM Replies r
+                    LEFT JOIN Users u ON u.user_id = r.user_id
+                    WHERE r.parent_post_id = %s
+                      AND r.is_deleted = FALSE
+                      AND u.is_deleted = FALSE
+                      AND r.user_id <> %s;
+                    """,
+                    (post_id, creator_id),
+                )
+                eligible_rows = cursor.fetchall()
+                eligible_map = {row["user_id"]: row["name"] for row in eligible_rows if row.get("user_id")}
+                valid_selected = [uid for uid in cleaned_selected_ids if uid in eligible_map]
+                if not valid_selected:
+                    cursor.close()
+                    return {"error": "Selected users must be commenters on this post"}, 400
+
+                group_id = str(uuid4())
+                effective_name = group_name or f"Diskussion: {post.get('content', '')[:40]}".strip()
+                if not effective_name:
+                    effective_name = "Ny diskussion"
+
+                cursor.execute(
+                    """
+                    INSERT INTO UserGroups (
+                        group_id, created_by, origin_post_id, name, description, created_at, updated_at
+                    )
+                    VALUES (%s, %s, %s, %s, %s, %s, %s);
+                    """,
+                    (
+                        group_id,
+                        creator_id,
+                        post_id,
+                        effective_name[:255],
+                        "Utbryten diskussion från kommentarstråd",
+                        now,
+                        now,
+                    ),
+                )
+
+                member_ids = [creator_id, *valid_selected]
+                unique_member_ids = list(dict.fromkeys(member_ids))
+                for member_id in unique_member_ids:
+                    cursor.execute(
+                        """
+                        INSERT INTO GroupMembers (group_id, user_id, joined_at, updated_at)
+                        VALUES (%s, %s, %s, %s);
+                        """,
+                        (group_id, member_id, now, now),
+                    )
+
+                cursor.execute(
+                    """
+                    UPDATE Posts
+                    SET restricted_group_id = %s,
+                        restricted_at = %s,
+                        replies_closed = TRUE,
+                        replies_closed_by = %s,
+                        replies_closed_at = %s,
+                        updated_at = %s
+                    WHERE post_id = %s;
+                    """,
+                    (group_id, now, creator_id, now, now, post_id),
+                )
+
+                cursor.close()
+
+            return {
+                "group_id": group_id,
+                "name": effective_name[:255],
+                "participant_count": len(unique_member_ids),
+                "participants": [
+                    {"id": uid, "name": eligible_map.get(uid, "Post owner")}
+                    for uid in unique_member_ids
+                ],
+            }, 201
+        except Exception as e:
+            logger.error(f"Error creating discussion group: {e}")
+            return {"error": "Failed to split discussion"}, 500
     
     return app

--- a/app/db.py
+++ b/app/db.py
@@ -162,9 +162,10 @@ def init_db(app: Flask) -> None:
                 cursor.execute(statement)
             except pymysql.Error as e:
                 # Reduce noise for idempotent schema operations
+                # 1060: Duplicate column name
                 # 1061: Duplicate key name (indexes)
                 # 1826: Duplicate foreign key constraint name
-                if e.args and e.args[0] in (1061, 1826):
+                if e.args and e.args[0] in (1060, 1061, 1826):
                     logger.debug(f"Schema statement skipped (already exists): {e}")
                 else:
                     logger.warning(f"Schema statement error (may be benign): {e}")
@@ -299,3 +300,42 @@ def ensure_default_admin(app: Flask) -> Optional[str]:
     except pymysql.Error as e:
         logger.error(f"Failed to ensure default admin: {e}")
         return None
+
+
+def ensure_post_thread_controls_schema(app: Flask) -> None:
+    """Ensure thread control columns/constraints exist on Posts table."""
+    statements = [
+        "ALTER TABLE Posts ADD COLUMN replies_closed BOOLEAN DEFAULT FALSE",
+        "ALTER TABLE Posts ADD COLUMN replies_closed_at DATETIME NULL",
+        "ALTER TABLE Posts ADD COLUMN replies_closed_by CHAR(36) NULL",
+        "ALTER TABLE Posts ADD COLUMN restricted_group_id CHAR(36) NULL",
+        "ALTER TABLE Posts ADD COLUMN restricted_at DATETIME NULL",
+        "ALTER TABLE Replies ADD COLUMN is_private_after_split BOOLEAN DEFAULT FALSE",
+        "CREATE INDEX idx_posts_replies_closed_by ON Posts(replies_closed_by)",
+        "CREATE INDEX idx_posts_restricted_group ON Posts(restricted_group_id)",
+        """
+        ALTER TABLE Posts
+        ADD CONSTRAINT fk_posts_replies_closed_by
+        FOREIGN KEY (replies_closed_by) REFERENCES Users(user_id) ON DELETE SET NULL
+        """,
+        """
+        ALTER TABLE Posts
+        ADD CONSTRAINT fk_posts_restricted_group
+        FOREIGN KEY (restricted_group_id) REFERENCES UserGroups(group_id) ON DELETE SET NULL
+        """,
+    ]
+    try:
+        with get_db(app) as conn:
+            cursor = conn.cursor()
+            for statement in statements:
+                try:
+                    cursor.execute(statement)
+                except pymysql.Error as e:
+                    if e.args and e.args[0] in (1060, 1061, 1826):
+                        logger.debug(f"Schema already up-to-date for thread controls: {e}")
+                    else:
+                        raise
+            cursor.close()
+            conn.commit()
+    except Exception as e:
+        logger.warning(f"Could not ensure thread control schema: {e}")

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -294,6 +294,35 @@ body {
   gap: 0.625rem;
 }
 
+.comments-list .comment-item + .comment-item {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 0.5rem;
+  padding-top: 0.625rem;
+}
+
+.thread-marker {
+  border-top: 1px dashed var(--border-color);
+  border-bottom: 1px dashed var(--border-color);
+  padding: 0.5rem 0;
+  margin: 0.25rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.thread-marker-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.thread-marker-time {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
 .comment-avatar {
   width: 28px;
   height: 28px;
@@ -340,6 +369,24 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.split-participants-list {
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+}
+
+.split-participants-list .form-check {
+  margin-bottom: 0.5rem;
+}
+
+.split-participants-empty {
+  color: var(--text-secondary);
+  margin: 0;
+  font-size: 0.875rem;
 }
 
 /* Status Badges */

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -46,6 +46,75 @@ function createCommentElement(comment) {
     return item;
 }
 
+function parseCommentParticipants(postCard) {
+    const raw = postCard?.dataset.commentParticipants;
+    if (!raw) return [];
+    try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (_err) {
+        return [];
+    }
+}
+
+function setThreadClosedState(postCard, isClosed) {
+    postCard.dataset.threadClosed = isClosed ? 'true' : 'false';
+
+    const lockIndicator = postCard.querySelector('.thread-locked-indicator');
+    if (lockIndicator) {
+        lockIndicator.classList.toggle('d-none', !isClosed);
+    }
+
+    const note = postCard.querySelector('.thread-closed-note');
+    if (note) {
+        note.classList.toggle('d-none', !isClosed);
+    }
+
+    const lockBtn = postCard.querySelector('.thread-lock-toggle-btn');
+    if (lockBtn) {
+        lockBtn.dataset.isClosed = isClosed ? 'true' : 'false';
+        if (postCard.dataset.threadRestricted === 'true') {
+            lockBtn.textContent = 'Svarstråd privat efter utbrytning';
+            lockBtn.disabled = true;
+        } else {
+            lockBtn.textContent = isClosed ? 'Öppna svarstråd' : 'Stäng svarstråd';
+            lockBtn.disabled = false;
+        }
+    }
+
+    const input = postCard.querySelector('.comment-input');
+    const submitBtn = postCard.querySelector('.comment-submit-btn');
+    const canComment = postCard.dataset.canComment === 'true';
+    if (input) {
+        input.disabled = !canComment;
+        input.placeholder = canComment ? 'Skriv en kommentar...' : 'Svarstråden är stängd.';
+    }
+    if (submitBtn) {
+        submitBtn.disabled = !canComment || !input?.value.trim();
+    }
+}
+
+function renderSplitParticipants(container, participants) {
+    container.innerHTML = '';
+    if (!participants.length) {
+        const empty = document.createElement('p');
+        empty.className = 'split-participants-empty';
+        empty.textContent = 'Inga kommentatorer att välja ännu.';
+        container.append(empty);
+        return;
+    }
+
+    participants.forEach((participant) => {
+        const check = document.createElement('div');
+        check.className = 'form-check';
+        check.innerHTML = `
+            <input class="form-check-input split-participant-checkbox" type="checkbox" value="${participant.id}" id="split_${participant.id}">
+            <label class="form-check-label" for="split_${participant.id}">${participant.name}</label>
+        `;
+        container.append(check);
+    });
+}
+
 
 // Rensa composer när modalen öppnas
 const composerModal = document.getElementById('composerModal');
@@ -155,6 +224,10 @@ document.querySelectorAll('.comment-time').forEach(el => {
     el.textContent = formatTimestamp(el.textContent);
 });
 
+document.querySelectorAll('.thread-marker-time').forEach(el => {
+    el.textContent = formatTimestamp(el.textContent);
+});
+
 document.addEventListener('click', async (e) => {
     const toggleBtn = e.target.closest('.comment-toggle-btn');
     if (toggleBtn) {
@@ -163,6 +236,58 @@ document.addEventListener('click', async (e) => {
         if (section) {
             section.classList.toggle('d-none');
         }
+        return;
+    }
+
+    const lockToggleBtn = e.target.closest('.thread-lock-toggle-btn');
+    if (lockToggleBtn) {
+        const postCard = lockToggleBtn.closest('.post-card');
+        const postId = postCard?.dataset.postId;
+        if (!postCard || !postId) return;
+        if (postCard.dataset.threadRestricted === 'true') {
+            showAlert('Svarstråden är privat efter utbrytning.', 'alert-info');
+            return;
+        }
+
+        const currentState = lockToggleBtn.dataset.isClosed === 'true';
+        lockToggleBtn.disabled = true;
+        try {
+            const response = await fetch(`/api/posts/${postId}/reply-lock`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ is_closed: !currentState }),
+            });
+            if (!response.ok) throw new Error('failed');
+            const payload = await response.json();
+            setThreadClosedState(postCard, Boolean(payload.is_closed));
+            showAlert(payload.is_closed ? 'Svarstråden är nu stängd.' : 'Svarstråden är nu öppen.', 'alert-info');
+        } catch (_err) {
+            showAlert('Kunde inte uppdatera svarstråden.', 'alert-danger');
+        } finally {
+            lockToggleBtn.disabled = false;
+        }
+        return;
+    }
+
+    const splitBtn = e.target.closest('.discussion-split-open-btn');
+    if (splitBtn) {
+        const modalEl = document.getElementById('splitDiscussionModal');
+        const postCard = splitBtn.closest('.post-card');
+        if (!modalEl || !postCard) return;
+
+        const participants = parseCommentParticipants(postCard);
+        const modal = new bootstrap.Modal(modalEl);
+        const postIdInput = document.getElementById('splitDiscussionPostId');
+        const nameInput = document.getElementById('splitDiscussionName');
+        const participantsContainer = document.getElementById('splitDiscussionParticipants');
+        const submitBtn = document.getElementById('splitDiscussionSubmitBtn');
+        if (!postIdInput || !nameInput || !participantsContainer || !submitBtn) return;
+
+        postIdInput.value = postCard.dataset.postId || '';
+        nameInput.value = '';
+        renderSplitParticipants(participantsContainer, participants);
+        submitBtn.disabled = participants.length === 0;
+        modal.show();
         return;
     }
 
@@ -177,6 +302,11 @@ document.addEventListener('click', async (e) => {
 
     const content = input.value.trim();
     if (!content) return;
+    const canComment = postCard.dataset.canComment === 'true';
+    if (!canComment) {
+        showAlert('Svarstråden är stängd för nya kommentarer.', 'alert-warning');
+        return;
+    }
 
     submitBtn.disabled = true;
     const previousLabel = submitBtn.textContent;
@@ -222,8 +352,64 @@ document.addEventListener('input', (e) => {
     const submitBtn = postCard?.querySelector('.comment-submit-btn');
     const length = commentInput.value.length;
     if (countEl) countEl.textContent = `${length}/500`;
-    if (submitBtn) submitBtn.disabled = length === 0 || length > 500;
+    if (submitBtn) {
+        submitBtn.disabled =
+            length === 0 || length > 500 || postCard?.dataset.canComment !== 'true';
+    }
 });
+
+const splitDiscussionSubmitBtn = document.getElementById('splitDiscussionSubmitBtn');
+if (splitDiscussionSubmitBtn) {
+    splitDiscussionSubmitBtn.addEventListener('click', async () => {
+        const modalEl = document.getElementById('splitDiscussionModal');
+        const postIdInput = document.getElementById('splitDiscussionPostId');
+        const nameInput = document.getElementById('splitDiscussionName');
+        const participantsContainer = document.getElementById('splitDiscussionParticipants');
+        if (!modalEl || !postIdInput || !nameInput || !participantsContainer) return;
+
+        const selected = Array.from(
+            participantsContainer.querySelectorAll('.split-participant-checkbox:checked')
+        ).map((el) => el.value);
+
+        if (!selected.length) {
+            showAlert('Välj minst en annan deltagare.', 'alert-warning');
+            return;
+        }
+
+        splitDiscussionSubmitBtn.disabled = true;
+        const previousText = splitDiscussionSubmitBtn.textContent;
+        splitDiscussionSubmitBtn.textContent = 'Skapar...';
+
+        try {
+            const response = await fetch(`/api/posts/${postIdInput.value}/discussion-groups`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: nameInput.value.trim(),
+                    participant_user_ids: selected,
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error('failed');
+            }
+            const payload = await response.json();
+            bootstrap.Modal.getInstance(modalEl)?.hide();
+            const postCard = document.querySelector(`.post-card[data-post-id="${postIdInput.value}"]`);
+            if (postCard) {
+                postCard.dataset.threadRestricted = 'true';
+                postCard.dataset.canComment = 'true';
+                setThreadClosedState(postCard, true);
+            }
+            showAlert(`Diskussion "${payload.name}" skapad.`, 'alert-success');
+        } catch (_err) {
+            showAlert('Kunde inte bryta ut diskussionen.', 'alert-danger');
+        } finally {
+            splitDiscussionSubmitBtn.disabled = false;
+            splitDiscussionSubmitBtn.textContent = previousText;
+        }
+    });
+}
 
 window.startInlineEdit = function(btn) {
     const postId = btn.dataset.postId;
@@ -304,7 +490,7 @@ window.confirmDelete = function(postId) {
 }
 
 
-window.showAlert = function(message, type, openModal) {
+function showAlert(message, type, openModal) {
     const toastContainer = document.getElementById('toast-container');
     if (!toastContainer) {
         console.error('No element with id "toast-container" found');
@@ -369,6 +555,8 @@ window.showAlert = function(message, type, openModal) {
         modal.show();
     }
 }
+
+window.showAlert = showAlert;
 
 const profileBio = document.getElementById('profile_bio');
 const profileBioCount = document.getElementById('profileBioCount');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -67,7 +67,12 @@
                 <!-- Posts Feed -->
                 <div id="postsFeed">
                     {% for post in posts %}
-                    <div class="post-card" data-post-id="{{ post.id }}">
+                    <div class="post-card"
+                         data-post-id="{{ post.id }}"
+                         data-thread-closed="{{ 'true' if post.threadClosed else 'false' }}"
+                         data-thread-restricted="{{ 'true' if post.threadRestricted else 'false' }}"
+                         data-can-comment="{{ 'true' if post.canComment else 'false' }}"
+                         data-comment-participants="{{ post.commentParticipants | tojson | forceescape }}">
                         <div class="d-flex gap-3">
                             <img src="{{ post.author.avatar }}" alt="{{ post.author.name }}" class="post-avatar">
                             <div class="flex-grow-1">
@@ -96,6 +101,28 @@
                                                     <i class="bi bi-trash me-2"></i>Delete
                                                 </button>
                                             </li>
+                                            <li><hr class="dropdown-divider"></li>
+                                            <li>
+                                                <button class="dropdown-item thread-lock-toggle-btn"
+                                                        type="button"
+                                                        data-is-closed="{{ 'true' if post.threadClosed else 'false' }}"
+                                                        {% if post.threadRestricted %}disabled{% endif %}>
+                                                    <i class="bi bi-chat-left-text me-2"></i>
+                                                    {% if post.threadRestricted %}
+                                                    Svarstråd privat efter utbrytning
+                                                    {% elif post.threadClosed %}
+                                                    Öppna svarstråd
+                                                    {% else %}
+                                                    Stäng svarstråd
+                                                    {% endif %}
+                                                </button>
+                                            </li>
+                                            <li>
+                                                <button class="dropdown-item discussion-split-open-btn"
+                                                        type="button">
+                                                    <i class="bi bi-diagram-3 me-2"></i>Bryt ut diskussion
+                                                </button>
+                                            </li>
                                             {% endif %}
                                         </ul>
                                     {% endif %}
@@ -106,6 +133,7 @@
                                     <button class="btn btn-link text-secondary action-btn comment-toggle-btn" type="button">
                                         <i class="bi bi-chat"></i>
                                         <span class="comment-count">{{ post.comments }}</span>
+                                        <i class="bi bi-lock-fill text-warning ms-1 thread-locked-indicator {% if not post.threadClosed %}d-none{% endif %}"></i>
                                     </button>
                                     <button class="btn btn-link action-btn like-btn {% if post.isLiked %}liked{% endif %}" data-action="like">
                                         <i class="bi {% if post.isLiked %}bi-heart-fill{% else %}bi-heart{% endif %}"></i>
@@ -116,31 +144,51 @@
                                     </button>
                                 </div>
                                 <div class="comments-section d-none">
-                                    <div class="comments-list">
-                                        {% for comment in post.commentsList %}
-                                        <div class="comment-item">
-                                            <img src="{{ comment.author.avatar }}" alt="{{ comment.author.name }}" class="comment-avatar">
-                                            <div class="comment-body">
-                                                <div class="comment-meta">
-                                                    <span class="comment-author">{{ comment.author.name }}</span>
-                                                    <span class="text-secondary">·</span>
-                                                    <span class="comment-time">{{ comment.timestamp }}</span>
+                                    {% if post.canViewComments %}
+                                        <div class="comments-list">
+                                            {% for comment in post.commentsList %}
+                                            {% if comment.isMarker %}
+                                            <div class="thread-marker">
+                                                <span class="thread-marker-label">{{ comment.label }}</span>
+                                                {% if comment.timestamp %}
+                                                <span class="thread-marker-time">{{ comment.timestamp }}</span>
+                                                {% endif %}
+                                            </div>
+                                            {% else %}
+                                            <div class="comment-item">
+                                                <img src="{{ comment.author.avatar }}" alt="{{ comment.author.name }}" class="comment-avatar">
+                                                <div class="comment-body">
+                                                    <div class="comment-meta">
+                                                        <span class="comment-author">{{ comment.author.name }}</span>
+                                                        <span class="text-secondary">·</span>
+                                                        <span class="comment-time">{{ comment.timestamp }}</span>
+                                                    </div>
+                                                    <p class="comment-content">{{ comment.content }}</p>
                                                 </div>
-                                                <p class="comment-content">{{ comment.content }}</p>
+                                            </div>
+                                            {% endif %}
+                                            {% endfor %}
+                                        </div>
+                                        {% if current_user.is_authenticated %}
+                                        <p class="text-warning small mb-2 thread-closed-note {% if not post.threadClosed or post.threadRestricted %}d-none{% endif %}">
+                                            Svarstråden är stängd för nya kommentarer.
+                                        </p>
+                                        {% if post.threadRestricted %}
+                                        <hr class="my-2">
+                                        <p class="text-info small mb-2">Privat diskussion. Endast utvalda deltagare kan svara.</p>
+                                        {% endif %}
+                                        <div class="comment-form">
+                                            <textarea class="form-control comment-input" rows="2" maxlength="500" placeholder="{% if not post.canComment %}Svarstråden är stängd.{% else %}Skriv en kommentar...{% endif %}" {% if not post.canComment %}disabled{% endif %}></textarea>
+                                            <div class="comment-form-footer">
+                                                <small class="text-secondary comment-charcount">0/500</small>
+                                                <button class="btn btn-primary btn-sm rounded-pill comment-submit-btn" type="button" disabled {% if not post.canComment %}disabled{% endif %}>Kommentera</button>
                                             </div>
                                         </div>
-                                        {% endfor %}
-                                    </div>
-                                    {% if current_user.is_authenticated %}
-                                    <div class="comment-form">
-                                        <textarea class="form-control comment-input" rows="2" maxlength="500" placeholder="Skriv en kommentar..."></textarea>
-                                        <div class="comment-form-footer">
-                                            <small class="text-secondary comment-charcount">0/500</small>
-                                            <button class="btn btn-primary btn-sm rounded-pill comment-submit-btn" type="button" disabled>Kommentera</button>
-                                        </div>
-                                    </div>
-                                    {% else %}
-                                    <p class="text-secondary small mb-0">Logga in för att kommentera.</p>
+                                        {% else %}
+                                        <p class="text-secondary small mb-0">Logga in för att kommentera.</p>
+                                        {% endif %}
+                                    {% elif post.threadRestricted %}
+                                    <p class="text-secondary small mb-0">Den här tråden är utbruten till en privat diskussion.</p>
                                     {% endif %}
                                 </div>
                             </div>
@@ -215,6 +263,33 @@
                             </div>
                         </div>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if current_user.is_authenticated %}
+    <div class="modal fade" id="splitDiscussionModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header border-0">
+                    <h5 class="modal-title">Bryt ut diskussion</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="splitDiscussionPostId">
+                    <div class="mb-3">
+                        <label for="splitDiscussionName" class="form-label">Namn på diskussion</label>
+                        <input type="text" id="splitDiscussionName" class="form-control" maxlength="255" placeholder="T.ex. Planering nästa steg">
+                    </div>
+                    <p class="small text-secondary mb-1">Välj vilka av kommentatorerna som ska följa med:</p>
+                    <p class="small text-secondary mb-2">Du läggs till automatiskt.</p>
+                    <div id="splitDiscussionParticipants" class="split-participants-list"></div>
+                </div>
+                <div class="modal-footer border-0">
+                    <button type="button" class="btn btn-outline-secondary rounded-pill" data-bs-dismiss="modal">Avbryt</button>
+                    <button type="button" class="btn btn-primary rounded-pill" id="splitDiscussionSubmitBtn">Skapa grupp</button>
                 </div>
             </div>
         </div>

--- a/schema.sql
+++ b/schema.sql
@@ -81,6 +81,11 @@ CREATE TABLE IF NOT EXISTS Posts (
     post_id CHAR(36) PRIMARY KEY,
     user_id CHAR(36) NOT NULL,
     content TEXT NOT NULL,
+    replies_closed BOOLEAN DEFAULT FALSE,
+    replies_closed_at DATETIME NULL,
+    replies_closed_by CHAR(36) NULL,
+    restricted_group_id CHAR(36) NULL,
+    restricted_at DATETIME NULL,
     is_deleted BOOLEAN DEFAULT FALSE,
     deleted_at DATETIME NULL,
     deleted_by CHAR(36) NULL,
@@ -91,6 +96,8 @@ CREATE TABLE IF NOT EXISTS Posts (
 CREATE INDEX idx_posts_user ON Posts(user_id);
 CREATE INDEX idx_posts_created_at ON Posts(created_at);
 CREATE INDEX idx_posts_deleted_by ON Posts(deleted_by);
+CREATE INDEX idx_posts_replies_closed_by ON Posts(replies_closed_by);
+CREATE INDEX idx_posts_restricted_group ON Posts(restricted_group_id);
 
 -- ----------------------------------------------------------
 
@@ -100,6 +107,7 @@ CREATE TABLE IF NOT EXISTS Replies (
     parent_reply_id CHAR(36) NULL,
     user_id CHAR(36) NOT NULL,
     content TEXT NOT NULL,
+    is_private_after_split BOOLEAN DEFAULT FALSE,
     is_deleted BOOLEAN DEFAULT FALSE,
     deleted_at DATETIME NULL,
     deleted_by CHAR(36) NULL,
@@ -288,6 +296,12 @@ ALTER TABLE BanHistory
 ALTER TABLE Posts
   ADD CONSTRAINT fk_posts_user FOREIGN KEY (user_id) REFERENCES Users(user_id) ON DELETE CASCADE,
   ADD CONSTRAINT fk_posts_deleted_by FOREIGN KEY (deleted_by) REFERENCES Users(user_id) ON DELETE SET NULL;
+
+ALTER TABLE Posts
+  ADD CONSTRAINT fk_posts_replies_closed_by FOREIGN KEY (replies_closed_by) REFERENCES Users(user_id) ON DELETE SET NULL;
+
+ALTER TABLE Posts
+  ADD CONSTRAINT fk_posts_restricted_group FOREIGN KEY (restricted_group_id) REFERENCES UserGroups(group_id) ON DELETE SET NULL;
 
 ALTER TABLE Replies
   ADD CONSTRAINT fk_replies_user FOREIGN KEY (user_id) REFERENCES Users(user_id) ON DELETE CASCADE,

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -25,6 +25,20 @@ def _register_user(client, suffix: str) -> dict:
     return {"response": resp, "username": username, "email": email, "password": password}
 
 
+def _login_user(client, username: str, password: str) -> None:
+    resp = client.post(
+        "/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 302
+
+
+def _logout_user(client) -> None:
+    resp = client.post("/logout", follow_redirects=False)
+    assert resp.status_code == 302
+
+
 def test_dashboard_loads(client):
     """Test dashboard page loads successfully."""
     resp = client.get("/dashboard")
@@ -134,6 +148,156 @@ def test_create_comment_authenticated(app, client):
     assert row is not None
     assert row["parent_post_id"] == post_id
     assert row["content"] == comment_content
+
+
+def test_closed_thread_blocks_new_comments(app, client):
+    """Post owner can close thread and new comments are blocked."""
+    owner_suffix = datetime.now().isoformat(timespec="seconds").replace(":", "") + "_owner"
+    owner = _register_user(client, owner_suffix)
+    assert owner["response"].status_code == 302
+
+    create_resp = client.post("/api/posts", json={"content": "Thread lock post"})
+    assert create_resp.status_code == 201
+    post_id = create_resp.get_json()["post_id"]
+
+    _logout_user(client)
+    commenter_suffix = datetime.now().isoformat(timespec="seconds").replace(":", "") + "_commenter"
+    commenter = _register_user(client, commenter_suffix)
+    assert commenter["response"].status_code == 302
+
+    first_comment = client.post(
+        f"/api/posts/{post_id}/comments",
+        json={"content": "First comment before lock"},
+    )
+    assert first_comment.status_code == 201
+
+    _logout_user(client)
+    _login_user(client, owner["username"], owner["password"])
+
+    lock_resp = client.post(
+        f"/api/posts/{post_id}/reply-lock",
+        json={"is_closed": True},
+    )
+    assert lock_resp.status_code == 200
+    assert lock_resp.get_json()["is_closed"] is True
+
+    _logout_user(client)
+    _login_user(client, commenter["username"], commenter["password"])
+
+    blocked_comment = client.post(
+        f"/api/posts/{post_id}/comments",
+        json={"content": "Should be blocked"},
+    )
+    assert blocked_comment.status_code == 403
+
+
+def test_split_discussion_selects_commenters(app, client):
+    """Owner can split discussion and select specific commenters."""
+    owner_suffix = datetime.now().isoformat(timespec="seconds").replace(":", "") + "_split_owner"
+    owner = _register_user(client, owner_suffix)
+    assert owner["response"].status_code == 302
+
+    create_resp = client.post("/api/posts", json={"content": "Split this discussion"})
+    assert create_resp.status_code == 201
+    post_id = create_resp.get_json()["post_id"]
+
+    _logout_user(client)
+    commenter_a = _register_user(client, datetime.now().isoformat(timespec="seconds").replace(":", "") + "_a")
+    assert commenter_a["response"].status_code == 302
+    comment_a_content = "A comment before split from selected user"
+    comment_a_resp = client.post(f"/api/posts/{post_id}/comments", json={"content": comment_a_content})
+    assert comment_a_resp.status_code == 201
+
+    _logout_user(client)
+    commenter_b = _register_user(client, datetime.now().isoformat(timespec="seconds").replace(":", "") + "_b")
+    assert commenter_b["response"].status_code == 302
+    comment_b_content = "B comment before split from non-selected user"
+    comment_b_resp = client.post(f"/api/posts/{post_id}/comments", json={"content": comment_b_content})
+    assert comment_b_resp.status_code == 201
+
+    _logout_user(client)
+    _login_user(client, owner["username"], owner["password"])
+
+    # Resolve commenter_a user id and retry with valid payload
+    with get_db(app) as conn:
+        cursor = conn.cursor(pymysql.cursors.DictCursor)
+        cursor.execute("SELECT user_id FROM Users WHERE username = %s", (commenter_a["username"],))
+        commenter_a_row = cursor.fetchone()
+        cursor.execute("SELECT user_id FROM Users WHERE username = %s", (owner["username"],))
+        owner_row = cursor.fetchone()
+        cursor.close()
+
+    assert commenter_a_row is not None
+    assert owner_row is not None
+
+    split_resp = client.post(
+        f"/api/posts/{post_id}/discussion-groups",
+        json={
+            "name": "Utbrytning test",
+            "participant_user_ids": [commenter_a_row["user_id"]],
+        },
+    )
+    assert split_resp.status_code == 201
+    payload = split_resp.get_json()
+    group_id = payload["group_id"]
+
+    reopen_resp = client.post(
+        f"/api/posts/{post_id}/reply-lock",
+        json={"is_closed": False},
+    )
+    assert reopen_resp.status_code == 400
+
+    with get_db(app) as conn:
+        cursor = conn.cursor(pymysql.cursors.DictCursor)
+        cursor.execute(
+            "SELECT name, origin_post_id, created_by FROM UserGroups WHERE group_id = %s",
+            (group_id,),
+        )
+        group_row = cursor.fetchone()
+        cursor.execute(
+            "SELECT user_id FROM GroupMembers WHERE group_id = %s ORDER BY user_id",
+            (group_id,),
+        )
+        member_rows = cursor.fetchall()
+        cursor.execute("SELECT user_id FROM Users WHERE username = %s", (commenter_b["username"],))
+        commenter_b_row = cursor.fetchone()
+        cursor.close()
+
+    assert group_row is not None
+    assert group_row["name"] == "Utbrytning test"
+    assert group_row["origin_post_id"] == post_id
+    assert group_row["created_by"] == owner_row["user_id"]
+    assert commenter_b_row is not None
+
+    member_ids = {row["user_id"] for row in member_rows}
+    assert owner_row["user_id"] in member_ids
+    assert commenter_a_row["user_id"] in member_ids
+    assert commenter_b_row["user_id"] not in member_ids
+
+    _logout_user(client)
+    _login_user(client, commenter_a["username"], commenter_a["password"])
+    private_after_split_content = "Only selected users should see this after split"
+    allowed_reply_resp = client.post(
+        f"/api/posts/{post_id}/comments",
+        json={"content": private_after_split_content},
+    )
+    assert allowed_reply_resp.status_code == 201
+    selected_dashboard_resp = client.get("/dashboard")
+    assert selected_dashboard_resp.status_code == 200
+    assert private_after_split_content.encode("utf-8") in selected_dashboard_resp.data
+
+    _logout_user(client)
+    _login_user(client, commenter_b["username"], commenter_b["password"])
+    blocked_reply_resp = client.post(
+        f"/api/posts/{post_id}/comments",
+        json={"content": "Should not be allowed after split"},
+    )
+    assert blocked_reply_resp.status_code == 403
+    dashboard_resp = client.get("/dashboard")
+    assert dashboard_resp.status_code == 200
+    assert comment_a_content.encode("utf-8") in dashboard_resp.data
+    assert comment_b_content.encode("utf-8") in dashboard_resp.data
+    assert private_after_split_content.encode("utf-8") not in dashboard_resp.data
 
 
 def test_echo_visible_on_dashboard(client):


### PR DESCRIPTION
## Summary
This PR adds threaded comment controls and private breakout discussions for posts.

## What’s included
- Create comments on posts.
- Post owner can close/open reply thread.
- Post owner can break out discussion into a private group and select participants.
- Owner is automatically included in breakout group (not selectable in UI).
- Visual marker in comment list for where thread was split/closed.
- Dropdown actions updated (thread controls moved under post menu).

## Access rules
- Comments posted **before** breakout remain visible to everyone.
- Comments posted **after** breakout are visible only to post owner + selected participants.
- Non-selected users cannot post new comments after breakout.
- If thread is privately broken out, it cannot be reopened to public replies.

## API endpoints
- `POST /api/posts/<post_id>/comments`
- `POST /api/posts/<post_id>/reply-lock`
- `POST /api/posts/<post_id>/discussion-groups`

## Schema changes
- `Posts.replies_closed`
- `Posts.replies_closed_at`
- `Posts.replies_closed_by`
- `Posts.restricted_group_id`
- `Posts.restricted_at`

## Tests / verification
- Added/updated API tests for:
  - comment creation
  - lock behavior
  - breakout participant behavior
  - visibility before/after breakout
- Fixed JS lint issue (`showAlert` no-undef).
