### PR TITLE
Add function to like posts and comments

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,6 +99,30 @@ def create_app(test_config: dict | None = None) -> Flask:
     app.register_blueprint(auth_bp)
     app.register_blueprint(profile_bp)
 
+    def _ensure_like_reaction_type(conn) -> str:
+        """Ensure a 'like' reaction type exists and return its ID."""
+        from uuid import uuid4
+
+        cursor = conn.cursor(cursors.DictCursor)
+        now = datetime.now().isoformat(timespec="seconds")
+        cursor.execute("SELECT reaction_type_id FROM ReactionTypes WHERE name = %s LIMIT 1", ("like",))
+        row = cursor.fetchone()
+        if row and row.get("reaction_type_id"):
+            reaction_type_id = row["reaction_type_id"]
+            cursor.close()
+            return reaction_type_id
+
+        reaction_type_id = str(uuid4())
+        cursor.execute(
+            """
+            INSERT INTO ReactionTypes (reaction_type_id, name, created_at, updated_at)
+            VALUES (%s, %s, %s, %s);
+            """,
+            (reaction_type_id, "like", now, now),
+        )
+        cursor.close()
+        return reaction_type_id
+
     # =================================================
     # Routes
     # =================================================
@@ -117,6 +141,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                            u.user_id, u.username, u.display_name,
                            m.url AS profile_image_url,
                            COALESCE(rc.reply_count, 0) AS reply_count,
+                           COALESCE(plc.like_count, 0) AS like_count,
                            COALESCE(p.replies_closed, FALSE) AS replies_closed,
                            p.replies_closed_at,
                            p.restricted_group_id,
@@ -147,7 +172,20 @@ def create_app(test_config: dict | None = None) -> Flask:
                                    END
                                WHEN p.restricted_group_id IS NULL AND COALESCE(p.replies_closed, FALSE) = FALSE THEN TRUE
                                ELSE FALSE
-                           END AS can_comment_replies
+                           END AS can_comment_replies,
+                           CASE
+                               WHEN %s IS NULL THEN FALSE
+                               WHEN EXISTS (
+                                   SELECT 1
+                                   FROM Reactions lr
+                                   JOIN ReactionTypes lrt ON lrt.reaction_type_id = lr.reaction_type_id
+                                   WHERE lr.post_id = p.post_id
+                                     AND lr.reply_id IS NULL
+                                     AND lr.user_id = %s
+                                     AND lrt.name = 'like'
+                               ) THEN TRUE
+                               ELSE FALSE
+                           END AS is_liked
                     FROM Posts p
                     LEFT JOIN Users u ON p.user_id = u.user_id
                     LEFT JOIN Media m ON m.media_id = u.profile_media_id AND m.is_deleted = FALSE
@@ -157,11 +195,29 @@ def create_app(test_config: dict | None = None) -> Flask:
                         WHERE is_deleted = FALSE
                         GROUP BY parent_post_id
                     ) rc ON rc.parent_post_id = p.post_id
+                    LEFT JOIN (
+                        SELECT r.post_id, COUNT(DISTINCT r.user_id) AS like_count
+                        FROM Reactions r
+                        JOIN ReactionTypes rt ON rt.reaction_type_id = r.reaction_type_id
+                        WHERE r.post_id IS NOT NULL
+                          AND r.reply_id IS NULL
+                          AND rt.name = 'like'
+                        GROUP BY r.post_id
+                    ) plc ON plc.post_id = p.post_id
                     WHERE p.is_deleted = FALSE
                     ORDER BY p.created_at DESC
                     LIMIT 50;
                     """,
-                    (viewer_id, viewer_id, viewer_id, viewer_id, viewer_id, viewer_id),
+                    (
+                        viewer_id,
+                        viewer_id,
+                        viewer_id,
+                        viewer_id,
+                        viewer_id,
+                        viewer_id,
+                        viewer_id,
+                        viewer_id,
+                    ),
                 )
                 db_posts = cursor.fetchall()
                 post_ids = [
@@ -177,15 +233,38 @@ def create_app(test_config: dict | None = None) -> Flask:
                         f"""
                         SELECT r.reply_id, r.parent_post_id, r.content, r.created_at,
                                COALESCE(r.is_private_after_split, FALSE) AS is_private_after_split,
+                               COALESCE(rlc.like_count, 0) AS like_count,
                                u.user_id, u.username, u.display_name,
-                               m.url AS profile_image_url
+                               m.url AS profile_image_url,
+                               CASE
+                                   WHEN %s IS NULL THEN FALSE
+                                   WHEN EXISTS (
+                                       SELECT 1
+                                       FROM Reactions rr
+                                       JOIN ReactionTypes rrt ON rrt.reaction_type_id = rr.reaction_type_id
+                                       WHERE rr.reply_id = r.reply_id
+                                         AND rr.post_id IS NULL
+                                         AND rr.user_id = %s
+                                         AND rrt.name = 'like'
+                                   ) THEN TRUE
+                                   ELSE FALSE
+                               END AS is_liked
                         FROM Replies r
                         LEFT JOIN Users u ON r.user_id = u.user_id
                         LEFT JOIN Media m ON m.media_id = u.profile_media_id AND m.is_deleted = FALSE
+                        LEFT JOIN (
+                            SELECT rx.reply_id, COUNT(DISTINCT rx.user_id) AS like_count
+                            FROM Reactions rx
+                            JOIN ReactionTypes rtx ON rtx.reaction_type_id = rx.reaction_type_id
+                            WHERE rx.reply_id IS NOT NULL
+                              AND rx.post_id IS NULL
+                              AND rtx.name = 'like'
+                            GROUP BY rx.reply_id
+                        ) rlc ON rlc.reply_id = r.reply_id
                         WHERE r.is_deleted = FALSE AND r.parent_post_id IN ({placeholders})
                         ORDER BY r.created_at ASC;
                         """,
-                        post_ids,
+                        (viewer_id, viewer_id, *post_ids),
                     )
                     db_replies = cursor.fetchall()
                     for reply in db_replies:
@@ -207,6 +286,8 @@ def create_app(test_config: dict | None = None) -> Flask:
                                 "content": reply.get("content"),
                                 "timestamp": reply.get("created_at"),
                                 "isPrivateAfterSplit": bool(reply.get("is_private_after_split")),
+                                "likes": int(reply.get("like_count") or 0),
+                                "isLiked": bool(reply.get("is_liked")),
                                 "author": {
                                     "id": reply.get("user_id"),
                                     "name": reply.get("display_name")
@@ -279,7 +360,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                         },
                         "content": row.get("content"),
                         "timestamp": row.get("created_at"),
-                        "likes": 0,
+                        "likes": int(row.get("like_count") or 0),
                         "comments": visible_comment_count,
                         "commentsList": rendered_comments,
                         "commentParticipants": (
@@ -296,7 +377,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                         "canComment": bool(row.get("can_comment_replies")),
                         "threadRestricted": bool(row.get("restricted_group_id")),
                         "bookmarks": 0,
-                        "isLiked": False,
+                        "isLiked": bool(row.get("is_liked")),
                         "isBookmarked": False,
                     }
                 )
@@ -467,6 +548,83 @@ def create_app(test_config: dict | None = None) -> Flask:
             logger.error(f"Error creating post (api): {e}")
             return {"error": "Failed to create post"}, 500
 
+    @app.route("/api/posts/<post_id>/like", methods=["POST"])
+    @login_required
+    def toggle_post_like_api(post_id):
+        from uuid import uuid4
+
+        user_id = current_user.get_id()
+        now = datetime.now().isoformat(timespec="seconds")
+
+        try:
+            with get_db(app) as conn:
+                cursor = conn.cursor(cursors.DictCursor)
+                cursor.execute(
+                    "SELECT post_id FROM Posts WHERE post_id = %s AND is_deleted = FALSE LIMIT 1",
+                    (post_id,),
+                )
+                post = cursor.fetchone()
+                if not post:
+                    cursor.close()
+                    return {"error": "Post not found"}, 404
+
+                like_reaction_type_id = _ensure_like_reaction_type(conn)
+                cursor.execute(
+                    """
+                    SELECT reaction_id
+                    FROM Reactions
+                    WHERE user_id = %s
+                      AND post_id = %s
+                      AND reply_id IS NULL
+                      AND reaction_type_id = %s
+                    LIMIT 1;
+                    """,
+                    (user_id, post_id, like_reaction_type_id),
+                )
+                existing = cursor.fetchone()
+                if existing:
+                    cursor.execute(
+                        """
+                        DELETE FROM Reactions
+                        WHERE user_id = %s
+                          AND post_id = %s
+                          AND reply_id IS NULL
+                          AND reaction_type_id = %s;
+                        """,
+                        (user_id, post_id, like_reaction_type_id),
+                    )
+                    is_liked = False
+                else:
+                    cursor.execute(
+                        """
+                        INSERT INTO Reactions (
+                            reaction_id, user_id, post_id, reply_id, reaction_type_id, created_at, updated_at
+                        )
+                        VALUES (%s, %s, %s, NULL, %s, %s, %s);
+                        """,
+                        (str(uuid4()), user_id, post_id, like_reaction_type_id, now, now),
+                    )
+                    is_liked = True
+
+                cursor.execute(
+                    """
+                    SELECT COUNT(DISTINCT r.user_id) AS likes
+                    FROM Reactions r
+                    JOIN ReactionTypes rt ON rt.reaction_type_id = r.reaction_type_id
+                    WHERE r.post_id = %s
+                      AND r.reply_id IS NULL
+                      AND rt.name = 'like';
+                    """,
+                    (post_id,),
+                )
+                likes_row = cursor.fetchone() or {}
+                cursor.close()
+
+            return {"post_id": post_id, "likes": int(likes_row.get("likes") or 0), "isLiked": is_liked}, 200
+        except Exception as e:
+            logger.error(f"Error toggling post like: {e}")
+            return {"error": "Failed to toggle like"}, 500
+
     @app.route("/api/posts/<post_id>/comments", methods=["POST"])
     @login_required
     def create_comment_api(post_id):
@@ -561,6 +719,106 @@ def create_app(test_config: dict | None = None) -> Flask:
         except Exception as e:
             logger.error(f"Error creating comment (api): {e}")
             return {"error": "Failed to create comment"}, 500
+
+    @app.route("/api/replies/<reply_id>/like", methods=["POST"])
+    @login_required
+    def toggle_reply_like_api(reply_id):
+        from uuid import uuid4
+
+        user_id = current_user.get_id()
+        now = datetime.now().isoformat(timespec="seconds")
+
+        try:
+            with get_db(app) as conn:
+                cursor = conn.cursor(cursors.DictCursor)
+                cursor.execute(
+                    """
+                    SELECT r.reply_id, r.parent_post_id, COALESCE(r.is_private_after_split, FALSE) AS is_private_after_split,
+                           p.user_id AS post_owner_id, p.restricted_group_id
+                    FROM Replies r
+                    LEFT JOIN Posts p ON p.post_id = r.parent_post_id
+                    WHERE r.reply_id = %s
+                      AND r.is_deleted = FALSE;
+                    """,
+                    (reply_id,),
+                )
+                reply = cursor.fetchone()
+                if not reply:
+                    cursor.close()
+                    return {"error": "Reply not found"}, 404
+
+                if reply.get("is_private_after_split") and reply.get("restricted_group_id"):
+                    cursor.execute(
+                        """
+                        SELECT 1
+                        FROM GroupMembers
+                        WHERE group_id = %s AND user_id = %s
+                        LIMIT 1;
+                        """,
+                        (reply.get("restricted_group_id"), user_id),
+                    )
+                    is_member = cursor.fetchone() is not None
+                    is_owner = reply.get("post_owner_id") == user_id
+                    if not is_member and not is_owner:
+                        cursor.close()
+                        return {"error": "Reply is private after split"}, 403
+
+                like_reaction_type_id = _ensure_like_reaction_type(conn)
+                cursor.execute(
+                    """
+                    SELECT reaction_id
+                    FROM Reactions
+                    WHERE user_id = %s
+                      AND reply_id = %s
+                      AND post_id IS NULL
+                      AND reaction_type_id = %s
+                    LIMIT 1;
+                    """,
+                    (user_id, reply_id, like_reaction_type_id),
+                )
+                existing = cursor.fetchone()
+                if existing:
+                    cursor.execute(
+                        """
+                        DELETE FROM Reactions
+                        WHERE user_id = %s
+                          AND reply_id = %s
+                          AND post_id IS NULL
+                          AND reaction_type_id = %s;
+                        """,
+                        (user_id, reply_id, like_reaction_type_id),
+                    )
+                    is_liked = False
+                else:
+                    cursor.execute(
+                        """
+                        INSERT INTO Reactions (
+                            reaction_id, user_id, post_id, reply_id, reaction_type_id, created_at, updated_at
+                        )
+                        VALUES (%s, %s, NULL, %s, %s, %s, %s);
+                        """,
+                        (str(uuid4()), user_id, reply_id, like_reaction_type_id, now, now),
+                    )
+                    is_liked = True
+
+                cursor.execute(
+                    """
+                    SELECT COUNT(DISTINCT r.user_id) AS likes
+                    FROM Reactions r
+                    JOIN ReactionTypes rt ON rt.reaction_type_id = r.reaction_type_id
+                    WHERE r.reply_id = %s
+                      AND r.post_id IS NULL
+                      AND rt.name = 'like';
+                    """,
+                    (reply_id,),
+                )
+                likes_row = cursor.fetchone() or {}
+                cursor.close()
+
+            return {"reply_id": reply_id, "likes": int(likes_row.get("likes") or 0), "isLiked": is_liked}, 200
+        except Exception as e:
+            logger.error(f"Error toggling reply like: {e}")
+            return {"error": "Failed to toggle reply like"}, 500
 
     @app.route("/api/posts/<post_id>/reply-lock", methods=["POST"])
     @login_required

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -355,6 +355,25 @@ body {
   line-height: 1.45;
 }
 
+.reply-actions {
+  margin-top: 0.25rem;
+}
+
+.reply-like-btn {
+  color: var(--text-secondary);
+  text-decoration: none;
+  padding: 0.15rem 0.25rem;
+  font-size: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.reply-like-btn:hover,
+.reply-like-btn.liked {
+  color: #ef4444;
+}
+
 .comment-form {
   margin-top: 0.75rem;
 }

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -40,8 +40,21 @@ function createCommentElement(comment) {
     content.className = 'comment-content';
     content.textContent = comment.content;
 
+    const replyActions = document.createElement('div');
+    replyActions.className = 'reply-actions';
+
+    const likeBtn = document.createElement('button');
+    likeBtn.type = 'button';
+    likeBtn.className = `btn btn-link reply-like-btn ${comment.isLiked ? 'liked' : ''}`.trim();
+    likeBtn.dataset.replyId = comment.reply_id || comment.id;
+    likeBtn.innerHTML = `
+        <i class="bi ${comment.isLiked ? 'bi-heart-fill' : 'bi-heart'}"></i>
+        <span class="reply-like-count">${comment.likes || 0}</span>
+    `;
+
+    replyActions.append(likeBtn);
     meta.append(author, separator, time);
-    body.append(meta, content);
+    body.append(meta, content, replyActions);
     item.append(avatar, body);
     return item;
 }
@@ -340,6 +353,37 @@ document.addEventListener('click', async (e) => {
     } finally {
         submitBtn.textContent = previousLabel;
         submitBtn.disabled = !input.value.trim();
+    }
+});
+
+document.addEventListener('click', async (e) => {
+    const likeBtn = e.target.closest('.reply-like-btn');
+    if (!likeBtn) return;
+
+    const replyId = likeBtn.dataset.replyId;
+    if (!replyId) return;
+
+    likeBtn.disabled = true;
+    try {
+        const response = await fetch(`/api/replies/${replyId}/like`, { method: 'POST' });
+        if (!response.ok) {
+            throw new Error('failed');
+        }
+        const payload = await response.json();
+        const icon = likeBtn.querySelector('i');
+        const count = likeBtn.querySelector('.reply-like-count');
+        likeBtn.classList.toggle('liked', Boolean(payload.isLiked));
+        if (icon) {
+            icon.classList.toggle('bi-heart-fill', Boolean(payload.isLiked));
+            icon.classList.toggle('bi-heart', !payload.isLiked);
+        }
+        if (count) {
+            count.textContent = `${payload.likes || 0}`;
+        }
+    } catch (_err) {
+        showAlert('Kunde inte gilla svaret.', 'alert-danger');
+    } finally {
+        likeBtn.disabled = false;
     }
 });
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -164,6 +164,12 @@
                                                         <span class="comment-time">{{ comment.timestamp }}</span>
                                                     </div>
                                                     <p class="comment-content">{{ comment.content }}</p>
+                                                    <div class="reply-actions">
+                                                        <button class="btn btn-link reply-like-btn {% if comment.isLiked %}liked{% endif %}" type="button" data-reply-id="{{ comment.id }}">
+                                                            <i class="bi {% if comment.isLiked %}bi-heart-fill{% else %}bi-heart{% endif %}"></i>
+                                                            <span class="reply-like-count">{{ comment.likes or 0 }}</span>
+                                                        </button>
+                                                    </div>
                                                 </div>
                                             </div>
                                             {% endif %}

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -58,6 +58,29 @@ def test_api_posts_requires_login(client):
     assert resp.status_code == 401
 
 
+def test_post_like_requires_login(client, app):
+    """Post like API should require authentication."""
+    post_id = str(uuid4())
+    now = datetime.now().isoformat(timespec="seconds")
+    with get_db(app) as conn:
+        cursor = conn.cursor(pymysql.cursors.DictCursor)
+        cursor.execute("SELECT user_id FROM Users WHERE is_deleted = FALSE LIMIT 1")
+        user_row = cursor.fetchone()
+        assert user_row is not None
+        cursor.execute(
+            """
+            INSERT INTO Posts (post_id, user_id, content, created_at, updated_at)
+            VALUES (%s, %s, %s, %s, %s)
+            """,
+            (post_id, user_row["user_id"], "Like auth post", now, now),
+        )
+        conn.commit()
+        cursor.close()
+
+    resp = client.post(f"/api/posts/{post_id}/like")
+    assert resp.status_code == 401
+
+
 def test_api_comments_requires_login(client, app):
     """Comment API should return 401 when unauthenticated."""
     post_id = str(uuid4())
@@ -148,6 +171,59 @@ def test_create_comment_authenticated(app, client):
     assert row is not None
     assert row["parent_post_id"] == post_id
     assert row["content"] == comment_content
+
+
+def test_toggle_post_like_authenticated(client):
+    """Authenticated user can like/unlike a post."""
+    suffix = datetime.now().isoformat(timespec="seconds").replace(":", "")
+    result = _register_user(client, suffix)
+    assert result["response"].status_code == 302
+
+    create_resp = client.post("/api/posts", json={"content": "Likeable post"})
+    assert create_resp.status_code == 201
+    post_id = create_resp.get_json()["post_id"]
+
+    like_resp = client.post(f"/api/posts/{post_id}/like")
+    assert like_resp.status_code == 200
+    like_payload = like_resp.get_json()
+    assert like_payload["isLiked"] is True
+    assert like_payload["likes"] == 1
+
+    unlike_resp = client.post(f"/api/posts/{post_id}/like")
+    assert unlike_resp.status_code == 200
+    unlike_payload = unlike_resp.get_json()
+    assert unlike_payload["isLiked"] is False
+    assert unlike_payload["likes"] == 0
+
+
+def test_toggle_reply_like_authenticated(client):
+    """Authenticated user can like/unlike a reply."""
+    suffix = datetime.now().isoformat(timespec="seconds").replace(":", "")
+    result = _register_user(client, suffix)
+    assert result["response"].status_code == 302
+
+    create_post_resp = client.post("/api/posts", json={"content": "Post with reply like"})
+    assert create_post_resp.status_code == 201
+    post_id = create_post_resp.get_json()["post_id"]
+
+    create_comment_resp = client.post(
+        f"/api/posts/{post_id}/comments",
+        json={"content": "A reply to like"},
+    )
+    assert create_comment_resp.status_code == 201
+    reply_id = create_comment_resp.get_json()["reply_id"]
+
+    like_resp = client.post(f"/api/replies/{reply_id}/like")
+    assert like_resp.status_code == 200
+    like_payload = like_resp.get_json()
+    assert like_payload["isLiked"] is True
+    assert like_payload["likes"] == 1
+
+    unlike_resp = client.post(f"/api/replies/{reply_id}/like")
+    assert unlike_resp.status_code == 200
+    unlike_payload = unlike_resp.get_json()
+    assert unlike_payload["isLiked"] is False
+    assert unlike_payload["likes"] == 0
 
 
 def test_closed_thread_blocks_new_comments(app, client):


### PR DESCRIPTION
## Summary
This PR adds full like support for both posts and replies in Echo.

## What Changed
- Added backend like toggle for posts.
- Added backend like toggle for replies.
- Added like counts and `isLiked` state in feed payload for posts and replies.
- Added UI like button + count for replies.
- Wired frontend toggle behavior for reply likes.
- Added API tests for auth + post like + reply like.

## API Endpoints
- `POST /api/posts/<post_id>/like`  
  Toggles like/unlike for the authenticated user on a post.
- `POST /api/replies/<reply_id>/like`  
  Toggles like/unlike for the authenticated user on a reply.

## Data Model / Behavior
- Reuses existing `Reactions` + `ReactionTypes` tables.
- Ensures `ReactionTypes.name='like'` exists before writing reactions.
- Counts are unique per user (`COUNT(DISTINCT user_id)`).

## Frontend
- Post like remains in existing action row.
- Reply like button added under each reply with heart icon + count.
- UI updates after API response (`liked` class + icon swap + count update).

## Tests
Added/updated tests in `tests/api/test_app.py`:
- `test_post_like_requires_login`
- `test_toggle_post_like_authenticated`
- `test_toggle_reply_like_authenticated`

Validation run:
- `npx eslint app/static/js/main.js` passed
- `./venv/bin/pytest -q tests/api/test_app.py -k "like and (post or reply)"` passed (`3 passed`)
