### PR TITLE
Add support for Pics and emojies

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ import os
 import logging
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlparse
 from dotenv import load_dotenv
 from flask import Flask, render_template, redirect, url_for, request, flash, jsonify
 from flask_login import LoginManager, current_user, login_required
@@ -99,6 +100,15 @@ def create_app(test_config: dict | None = None) -> Flask:
     app.register_blueprint(auth_bp)
     app.register_blueprint(profile_bp)
 
+    def _is_valid_http_url(value: str) -> bool:
+        if not value:
+            return False
+        try:
+            parsed = urlparse(value)
+            return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+        except Exception:
+            return False
+
     def _ensure_like_reaction_type(conn) -> str:
         """Ensure a 'like' reaction type exists and return its ID."""
         from uuid import uuid4
@@ -140,6 +150,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                     SELECT p.post_id, p.content, p.created_at, p.updated_at,
                            u.user_id, u.username, u.display_name,
                            m.url AS profile_image_url,
+                           pm.url AS post_image_url,
                            COALESCE(rc.reply_count, 0) AS reply_count,
                            COALESCE(plc.like_count, 0) AS like_count,
                            COALESCE(p.replies_closed, FALSE) AS replies_closed,
@@ -190,6 +201,22 @@ def create_app(test_config: dict | None = None) -> Flask:
                     LEFT JOIN Users u ON p.user_id = u.user_id
                     LEFT JOIN Media m ON m.media_id = u.profile_media_id AND m.is_deleted = FALSE
                     LEFT JOIN (
+                        SELECT m1.post_id, m1.url
+                        FROM Media m1
+                        JOIN (
+                            SELECT post_id, MIN(created_at) AS min_created_at
+                            FROM Media
+                            WHERE post_id IS NOT NULL
+                              AND media_type = 'image'
+                              AND is_deleted = FALSE
+                            GROUP BY post_id
+                        ) first_media
+                          ON first_media.post_id = m1.post_id
+                         AND first_media.min_created_at = m1.created_at
+                        WHERE m1.media_type = 'image'
+                          AND m1.is_deleted = FALSE
+                    ) pm ON pm.post_id = p.post_id
+                    LEFT JOIN (
                         SELECT parent_post_id, COUNT(*) AS reply_count
                         FROM Replies
                         WHERE is_deleted = FALSE
@@ -236,6 +263,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                                COALESCE(rlc.like_count, 0) AS like_count,
                                u.user_id, u.username, u.display_name,
                                m.url AS profile_image_url,
+                               rm.url AS reply_image_url,
                                CASE
                                    WHEN %s IS NULL THEN FALSE
                                    WHEN EXISTS (
@@ -252,6 +280,22 @@ def create_app(test_config: dict | None = None) -> Flask:
                         FROM Replies r
                         LEFT JOIN Users u ON r.user_id = u.user_id
                         LEFT JOIN Media m ON m.media_id = u.profile_media_id AND m.is_deleted = FALSE
+                        LEFT JOIN (
+                            SELECT m2.reply_id, m2.url
+                            FROM Media m2
+                            JOIN (
+                                SELECT reply_id, MIN(created_at) AS min_created_at
+                                FROM Media
+                                WHERE reply_id IS NOT NULL
+                                  AND media_type = 'image'
+                                  AND is_deleted = FALSE
+                                GROUP BY reply_id
+                            ) first_reply_media
+                              ON first_reply_media.reply_id = m2.reply_id
+                             AND first_reply_media.min_created_at = m2.created_at
+                            WHERE m2.media_type = 'image'
+                              AND m2.is_deleted = FALSE
+                        ) rm ON rm.reply_id = r.reply_id
                         LEFT JOIN (
                             SELECT rx.reply_id, COUNT(DISTINCT rx.user_id) AS like_count
                             FROM Reactions rx
@@ -285,6 +329,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                                 "id": reply.get("reply_id"),
                                 "content": reply.get("content"),
                                 "timestamp": reply.get("created_at"),
+                                "imageUrl": reply.get("reply_image_url"),
                                 "isPrivateAfterSplit": bool(reply.get("is_private_after_split")),
                                 "likes": int(reply.get("like_count") or 0),
                                 "isLiked": bool(reply.get("is_liked")),
@@ -359,6 +404,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                             "avatar": row.get("profile_image_url") or default_avatar_url,
                         },
                         "content": row.get("content"),
+                        "imageUrl": row.get("post_image_url"),
                         "timestamp": row.get("created_at"),
                         "likes": int(row.get("like_count") or 0),
                         "comments": visible_comment_count,
@@ -518,10 +564,13 @@ def create_app(test_config: dict | None = None) -> Flask:
 
         payload = request.get_json(silent=True) or {}
         content = (payload.get("content") or "").strip()
+        image_url = (payload.get("image_url") or "").strip()
         user_id = current_user.get_id()
 
         if not content:
             return {"error": "Content is required"}, 400
+        if image_url and not _is_valid_http_url(image_url):
+            return {"error": "image_url must be a valid http/https URL"}, 400
 
         try:
             post_id = str(uuid4())
@@ -536,11 +585,21 @@ def create_app(test_config: dict | None = None) -> Flask:
                     """,
                     (post_id, user_id, content, now, now),
                 )
+                if image_url:
+                    media_id = str(uuid4())
+                    cursor.execute(
+                        """
+                        INSERT INTO Media (media_id, post_id, reply_id, url, media_type, created_at, updated_at)
+                        VALUES (%s, %s, NULL, %s, %s, %s, %s);
+                        """,
+                        (media_id, post_id, image_url, "image", now, now),
+                    )
                 cursor.close()
 
             return {
                 "post_id": post_id,
                 "content": content,
+                "image_url": image_url or None,
                 "created_at": now,
                 "user_id": user_id,
             }, 201
@@ -637,6 +696,7 @@ def create_app(test_config: dict | None = None) -> Flask:
 
         payload = request.get_json(silent=True) or {}
         content = (payload.get("content") or "").strip()
+        image_url = (payload.get("image_url") or "").strip()
         user_id = current_user.get_id()
 
         if not content:
@@ -644,6 +704,8 @@ def create_app(test_config: dict | None = None) -> Flask:
 
         if len(content) > 500:
             return {"error": "Max 500 characters"}, 400
+        if image_url and not _is_valid_http_url(image_url):
+            return {"error": "image_url must be a valid http/https URL"}, 400
 
         try:
             now = datetime.now().isoformat(timespec="seconds")
@@ -692,6 +754,14 @@ def create_app(test_config: dict | None = None) -> Flask:
                     """,
                     (reply_id, post_id, user_id, content, is_private_thread, now, now),
                 )
+                if image_url:
+                    cursor.execute(
+                        """
+                        INSERT INTO Media (media_id, post_id, reply_id, url, media_type, created_at, updated_at)
+                        VALUES (%s, NULL, %s, %s, %s, %s, %s);
+                        """,
+                        (str(uuid4()), reply_id, image_url, "image", now, now),
+                    )
 
                 cursor.execute(
                     """
@@ -709,6 +779,7 @@ def create_app(test_config: dict | None = None) -> Flask:
                 "reply_id": reply_id,
                 "post_id": post_id,
                 "content": content,
+                "image_url": image_url or None,
                 "created_at": now,
                 "author": {
                     "id": author.get("user_id"),

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -235,6 +235,25 @@ body {
   line-height: 1.5;
 }
 
+.post-image {
+  width: 100%;
+  max-height: 420px;
+  object-fit: cover;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-color);
+  margin-bottom: 0.75rem;
+}
+
+.emoji-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.emoji-choice {
+  min-width: 2.2rem;
+}
+
 .post-actions {
   display: flex;
   gap: 1rem;
@@ -355,6 +374,15 @@ body {
   line-height: 1.45;
 }
 
+.comment-image {
+  width: 100%;
+  max-height: 260px;
+  object-fit: cover;
+  border-radius: 0.625rem;
+  border: 1px solid var(--border-color);
+  margin-top: 0.45rem;
+}
+
 .reply-actions {
   margin-top: 0.25rem;
 }
@@ -376,6 +404,12 @@ body {
 
 .comment-form {
   margin-top: 0.75rem;
+}
+
+.comment-emoji-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
 .comment-input {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -2,6 +2,11 @@
 const postBtn = document.getElementById('postBtn');
 const postContent = document.getElementById('postContent');
 const charCount = document.getElementById('charCount');
+const postImageUrl = document.getElementById('postImageUrl');
+const composerImageUrlWrap = document.getElementById('composerImageUrlWrap');
+const toggleImageUrlBtn = document.getElementById('toggleImageUrlBtn');
+const emojiPicker = document.getElementById('emojiPicker');
+const toggleEmojiPickerBtn = document.getElementById('toggleEmojiPickerBtn');
 
 function formatTimestamp(raw) {
     const date = new Date(raw);
@@ -40,6 +45,15 @@ function createCommentElement(comment) {
     content.className = 'comment-content';
     content.textContent = comment.content;
 
+    const imageUrl = comment.image_url || comment.imageUrl;
+    let imageEl = null;
+    if (imageUrl) {
+        imageEl = document.createElement('img');
+        imageEl.className = 'comment-image';
+        imageEl.src = imageUrl;
+        imageEl.alt = 'Comment image';
+    }
+
     const replyActions = document.createElement('div');
     replyActions.className = 'reply-actions';
 
@@ -54,7 +68,11 @@ function createCommentElement(comment) {
 
     replyActions.append(likeBtn);
     meta.append(author, separator, time);
-    body.append(meta, content, replyActions);
+    if (imageEl) {
+        body.append(meta, content, imageEl, replyActions);
+    } else {
+        body.append(meta, content, replyActions);
+    }
     item.append(avatar, body);
     return item;
 }
@@ -131,12 +149,15 @@ function renderSplitParticipants(container, participants) {
 
 // Rensa composer när modalen öppnas
 const composerModal = document.getElementById('composerModal');
-if (composerModal) {
+    if (composerModal) {
     composerModal.addEventListener('show.bs.modal', () => {
         const textarea = document.getElementById('postContent');
         const charCount = document.getElementById('charCount');
         if (textarea) textarea.value = '';
         if (charCount) charCount.textContent = '0/500';
+        if (postImageUrl) postImageUrl.value = '';
+        if (composerImageUrlWrap) composerImageUrlWrap.classList.add('d-none');
+        if (emojiPicker) emojiPicker.classList.add('d-none');
     });
 
     // Teckenräknare
@@ -159,22 +180,51 @@ if (postBtn && postContent && charCount) {
     postBtn.addEventListener('click', async () => {
         const content = postContent.value.trim();
         if (!content) return;
+        const imageUrl = (postImageUrl?.value || '').trim();
 
         try {
             const response = await fetch('/api/posts', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ content }),
+                body: JSON.stringify({ content, image_url: imageUrl }),
             });
 
             if (response.ok) {
                 location.reload();
+            } else {
+                showAlert('Kunde inte skapa inlägget.', 'alert-danger');
             }
         } catch (error) {
             console.error('Error creating post:', error);
         }
     });
 }
+
+if (toggleImageUrlBtn && composerImageUrlWrap) {
+    toggleImageUrlBtn.addEventListener('click', () => {
+        composerImageUrlWrap.classList.toggle('d-none');
+        if (!composerImageUrlWrap.classList.contains('d-none')) {
+            postImageUrl?.focus();
+        }
+    });
+}
+
+if (toggleEmojiPickerBtn && emojiPicker) {
+    toggleEmojiPickerBtn.addEventListener('click', () => {
+        emojiPicker.classList.toggle('d-none');
+    });
+}
+
+document.addEventListener('click', (e) => {
+    const emojiBtn = e.target.closest('.emoji-choice');
+    if (!emojiBtn || !postContent) return;
+    const emoji = emojiBtn.textContent || '';
+    postContent.value += emoji;
+    const length = postContent.value.length;
+    if (charCount) charCount.textContent = `${length}/500`;
+    if (postBtn) postBtn.disabled = length === 0 || length > 500;
+    postContent.focus();
+});
 
 // Like/Bookmark actions
 document.addEventListener('click', async (e) => {
@@ -304,16 +354,57 @@ document.addEventListener('click', async (e) => {
         return;
     }
 
+    const commentImageToggleBtn = e.target.closest('.comment-image-toggle-btn');
+    if (commentImageToggleBtn) {
+        const postCard = commentImageToggleBtn.closest('.post-card');
+        const imageWrap = postCard?.querySelector('.comment-image-url-wrap');
+        const imageInput = postCard?.querySelector('.comment-image-url-input');
+        if (!imageWrap) return;
+        imageWrap.classList.toggle('d-none');
+        if (!imageWrap.classList.contains('d-none')) {
+            imageInput?.focus();
+        }
+        return;
+    }
+
+    const commentEmojiToggleBtn = e.target.closest('.comment-emoji-toggle-btn');
+    if (commentEmojiToggleBtn) {
+        const postCard = commentEmojiToggleBtn.closest('.post-card');
+        const picker = postCard?.querySelector('.comment-emoji-picker');
+        if (!picker) return;
+        picker.classList.toggle('d-none');
+        return;
+    }
+
+    const commentEmojiChoiceBtn = e.target.closest('.comment-emoji-choice');
+    if (commentEmojiChoiceBtn) {
+        const postCard = commentEmojiChoiceBtn.closest('.post-card');
+        const input = postCard?.querySelector('.comment-input');
+        const submitBtn = postCard?.querySelector('.comment-submit-btn');
+        const countEl = postCard?.querySelector('.comment-charcount');
+        if (!input) return;
+        input.value += (commentEmojiChoiceBtn.textContent || '');
+        const length = input.value.length;
+        if (countEl) countEl.textContent = `${length}/500`;
+        if (submitBtn) {
+            submitBtn.disabled = length === 0 || length > 500 || postCard?.dataset.canComment !== 'true';
+        }
+        input.focus();
+        return;
+    }
+
     const submitBtn = e.target.closest('.comment-submit-btn');
     if (!submitBtn) return;
 
     const postCard = submitBtn.closest('.post-card');
     const input = postCard?.querySelector('.comment-input');
+    const imageInput = postCard?.querySelector('.comment-image-url-input');
     const commentsList = postCard?.querySelector('.comments-list');
     const postId = postCard?.dataset.postId;
     if (!postCard || !input || !commentsList || !postId) return;
 
     const content = input.value.trim();
+    const imageUrl = (imageInput?.value || '').trim();
     if (!content) return;
     const canComment = postCard.dataset.canComment === 'true';
     if (!canComment) {
@@ -329,7 +420,7 @@ document.addEventListener('click', async (e) => {
         const response = await fetch(`/api/posts/${postId}/comments`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ content }),
+            body: JSON.stringify({ content, image_url: imageUrl }),
         });
 
         if (!response.ok) {
@@ -339,6 +430,11 @@ document.addEventListener('click', async (e) => {
         const comment = await response.json();
         commentsList.append(createCommentElement(comment));
         input.value = '';
+        if (imageInput) imageInput.value = '';
+        const imageWrap = postCard.querySelector('.comment-image-url-wrap');
+        if (imageWrap) imageWrap.classList.add('d-none');
+        const emojiPickerEl = postCard.querySelector('.comment-emoji-picker');
+        if (emojiPickerEl) emojiPickerEl.classList.add('d-none');
 
         const charCountEl = postCard.querySelector('.comment-charcount');
         if (charCountEl) charCountEl.textContent = '0/500';

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -129,6 +129,9 @@
                                     </div>
                                 </div>
                                 <p class="post-content">{{ post.content }}</p>
+                                {% if post.imageUrl %}
+                                <img src="{{ post.imageUrl }}" alt="Post image" class="post-image">
+                                {% endif %}
                                 <div class="post-actions">
                                     <button class="btn btn-link text-secondary action-btn comment-toggle-btn" type="button">
                                         <i class="bi bi-chat"></i>
@@ -164,6 +167,9 @@
                                                         <span class="comment-time">{{ comment.timestamp }}</span>
                                                     </div>
                                                     <p class="comment-content">{{ comment.content }}</p>
+                                                    {% if comment.imageUrl %}
+                                                    <img src="{{ comment.imageUrl }}" alt="Comment image" class="comment-image">
+                                                    {% endif %}
                                                     <div class="reply-actions">
                                                         <button class="btn btn-link reply-like-btn {% if comment.isLiked %}liked{% endif %}" type="button" data-reply-id="{{ comment.id }}">
                                                             <i class="bi {% if comment.isLiked %}bi-heart-fill{% else %}bi-heart{% endif %}"></i>
@@ -185,8 +191,25 @@
                                         {% endif %}
                                         <div class="comment-form">
                                             <textarea class="form-control comment-input" rows="2" maxlength="500" placeholder="{% if not post.canComment %}Svarstråden är stängd.{% else %}Skriv en kommentar...{% endif %}" {% if not post.canComment %}disabled{% endif %}></textarea>
+                                            <div class="comment-image-url-wrap mt-2 d-none">
+                                                <input class="form-control comment-image-url-input" type="url" placeholder="Paste image URL (https://...)">
+                                            </div>
+                                            <div class="comment-emoji-picker d-none mt-2">
+                                                <button class="btn btn-sm btn-outline-secondary comment-emoji-choice" type="button">😀</button>
+                                                <button class="btn btn-sm btn-outline-secondary comment-emoji-choice" type="button">😂</button>
+                                                <button class="btn btn-sm btn-outline-secondary comment-emoji-choice" type="button">😍</button>
+                                                <button class="btn btn-sm btn-outline-secondary comment-emoji-choice" type="button">🔥</button>
+                                                <button class="btn btn-sm btn-outline-secondary comment-emoji-choice" type="button">🙏</button>
+                                                <button class="btn btn-sm btn-outline-secondary comment-emoji-choice" type="button">👍</button>
+                                                <button class="btn btn-sm btn-outline-secondary comment-emoji-choice" type="button">🎉</button>
+                                                <button class="btn btn-sm btn-outline-secondary comment-emoji-choice" type="button">💯</button>
+                                            </div>
                                             <div class="comment-form-footer">
-                                                <small class="text-secondary comment-charcount">0/500</small>
+                                                <div class="d-flex gap-2 align-items-center">
+                                                    <button class="btn btn-link text-secondary p-0 comment-image-toggle-btn" type="button"><i class="bi bi-image"></i></button>
+                                                    <button class="btn btn-link text-secondary p-0 comment-emoji-toggle-btn" type="button"><i class="bi bi-emoji-smile"></i></button>
+                                                    <small class="text-secondary comment-charcount">0/500</small>
+                                                </div>
                                                 <button class="btn btn-primary btn-sm rounded-pill comment-submit-btn" type="button" disabled {% if not post.canComment %}disabled{% endif %}>Kommentera</button>
                                             </div>
                                         </div>
@@ -256,10 +279,23 @@
                         <img src="{{ current_user.profile_image_url or default_avatar_url }}" alt="User avatar" class="post-avatar">
                         <div class="flex-grow-1">
                             <textarea class="form-control composer-textarea" id="postContent" placeholder="What do you want to echo?" maxlength="500"></textarea>
+                            <div id="composerImageUrlWrap" class="mt-2 d-none">
+                                <input class="form-control" id="postImageUrl" type="url" placeholder="Paste image URL (https://...)">
+                            </div>
+                            <div id="emojiPicker" class="emoji-picker d-none mt-2">
+                                <button class="btn btn-sm btn-outline-secondary emoji-choice" type="button">😀</button>
+                                <button class="btn btn-sm btn-outline-secondary emoji-choice" type="button">😂</button>
+                                <button class="btn btn-sm btn-outline-secondary emoji-choice" type="button">😍</button>
+                                <button class="btn btn-sm btn-outline-secondary emoji-choice" type="button">🔥</button>
+                                <button class="btn btn-sm btn-outline-secondary emoji-choice" type="button">🙏</button>
+                                <button class="btn btn-sm btn-outline-secondary emoji-choice" type="button">👍</button>
+                                <button class="btn btn-sm btn-outline-secondary emoji-choice" type="button">🎉</button>
+                                <button class="btn btn-sm btn-outline-secondary emoji-choice" type="button">💯</button>
+                            </div>
                             <div class="composer-actions mt-2">
                                 <div class="d-flex gap-2">
-                                    <button class="btn btn-link text-secondary"><i class="bi bi-image"></i></button>
-                                    <button class="btn btn-link text-secondary"><i class="bi bi-emoji-smile"></i></button>
+                                    <button class="btn btn-link text-secondary" id="toggleImageUrlBtn" type="button"><i class="bi bi-image"></i></button>
+                                    <button class="btn btn-link text-secondary" id="toggleEmojiPickerBtn" type="button"><i class="bi bi-emoji-smile"></i></button>
                                 </div>
                                 <div class="d-flex gap-2 align-items-center">
                                     <span class="text-secondary small" id="charCount">0/500</span>

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -226,6 +226,74 @@ def test_toggle_reply_like_authenticated(client):
     assert unlike_payload["likes"] == 0
 
 
+def test_create_post_with_image_url_authenticated(app, client):
+    """Authenticated user can create post with image URL."""
+    suffix = datetime.now().isoformat(timespec="seconds").replace(":", "")
+    result = _register_user(client, suffix)
+    assert result["response"].status_code == 302
+
+    image_url = "https://images.unsplash.com/photo-1518770660439-4636190af475?w=1200"
+    create_resp = client.post(
+        "/api/posts",
+        json={"content": "Post with image", "image_url": image_url},
+    )
+    assert create_resp.status_code == 201
+    post_id = create_resp.get_json()["post_id"]
+
+    with get_db(app) as conn:
+        cursor = conn.cursor(pymysql.cursors.DictCursor)
+        cursor.execute(
+            """
+            SELECT url, media_type
+            FROM Media
+            WHERE post_id = %s AND is_deleted = FALSE
+            """,
+            (post_id,),
+        )
+        media_row = cursor.fetchone()
+        cursor.close()
+
+    assert media_row is not None
+    assert media_row["url"] == image_url
+    assert media_row["media_type"] == "image"
+
+
+def test_create_comment_with_image_url_authenticated(app, client):
+    """Authenticated user can create comment with image URL."""
+    suffix = datetime.now().isoformat(timespec="seconds").replace(":", "")
+    result = _register_user(client, suffix)
+    assert result["response"].status_code == 302
+
+    post_resp = client.post("/api/posts", json={"content": "Post for comment image"})
+    assert post_resp.status_code == 201
+    post_id = post_resp.get_json()["post_id"]
+
+    image_url = "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=1200"
+    comment_resp = client.post(
+        f"/api/posts/{post_id}/comments",
+        json={"content": "Comment with image", "image_url": image_url},
+    )
+    assert comment_resp.status_code == 201
+    reply_id = comment_resp.get_json()["reply_id"]
+
+    with get_db(app) as conn:
+        cursor = conn.cursor(pymysql.cursors.DictCursor)
+        cursor.execute(
+            """
+            SELECT url, media_type
+            FROM Media
+            WHERE reply_id = %s AND is_deleted = FALSE
+            """,
+            (reply_id,),
+        )
+        media_row = cursor.fetchone()
+        cursor.close()
+
+    assert media_row is not None
+    assert media_row["url"] == image_url
+    assert media_row["media_type"] == "image"
+
+
 def test_closed_thread_blocks_new_comments(app, client):
     """Post owner can close thread and new comments are blocked."""
     owner_suffix = datetime.now().isoformat(timespec="seconds").replace(":", "") + "_owner"


### PR DESCRIPTION
## Summary
This PR adds media and emoji support to post creation, and extends the same capabilities to comment creation.

## What’s included
- Add image URL support when creating a post.
- Add image URL support when creating a comment/reply.
- Add emoji picker in post composer.
- Add emoji picker in comment composer.
- Render post images in feed.
- Render comment images in thread view.

## Backend changes
- `POST /api/posts` now accepts optional `image_url`.
- `POST /api/posts/<post_id>/comments` now accepts optional `image_url`.
- URL validation for `image_url` (must be valid `http/https`).
- Stores media in `Media` table:
  - post image: `Media.post_id`
  - reply image: `Media.reply_id`
- Feed queries now include:
  - first image for each post
  - first image for each reply

## Frontend changes
- Post composer:
  - image URL toggle/input
  - emoji picker toggle with quick-insert emojis
- Comment composer:
  - image URL toggle/input
  - emoji picker toggle with quick-insert emojis
- Thread rendering:
  - comment image preview support
- Existing like/comment flows remain intact.

## Files changed
- `app/__init__.py`
- `app/templates/index.html`
- `app/static/js/main.js`
- `app/static/css/style.css`
- `tests/api/test_app.py`

## Tests
Added/updated API tests:
- create post with `image_url`
- create comment with `image_url`
- existing like/comment tests still passing

Validation run:
- `npx eslint app/static/js/main.js` passed
- `./venv/bin/pytest -q tests/api/test_app.py -k "image_url or like or create_comment_authenticated"` passed (`6 passed`)
